### PR TITLE
Game Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ RUNNING_PID
 /modules/*/.classpath
 /modules/*/.project
 /modules/*/.settings/
+
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,8 @@ lazy val user = module("user", Seq(common, memo, db, hub, rating)).settings(
 )
 
 lazy val game = module("game", Seq(common, memo, db, hub, user, chat)).settings(
-  libraryDependencies ++= provided(play.api, reactivemongo.driver, reactivemongo.iteratees)
+  libraryDependencies ++= provided(play.api, reactivemongo.driver, reactivemongo.iteratees),
+  libraryDependencies += mockito
 )
 
 lazy val gameSearch = module("gameSearch", Seq(common, hub, search, game)).settings(

--- a/modules/game/src/test/GameTest.scala
+++ b/modules/game/src/test/GameTest.scala
@@ -1,9 +1,9 @@
 package lila.game
 
 import chess.Color.{ Black, White }
-import chess.{ Status, UnmovedRooks }
+import chess.{ Color, Status, UnmovedRooks }
 import lila.db.ByteArray
-import lila.game.Source.Lobby
+import lila.game.Source.{ Import, Lobby }
 import org.mockito.Mockito._
 import org.specs2.mutable._
 
@@ -17,50 +17,32 @@ class GameTest extends Specification {
   private val defaultMockMetadata = mock(classOf[Metadata])
 
   // ByteArray instances (parameter for new Game)
-  // NOTE: Could not mock ByteArray, received error saying unable to mock static/final classes. Will look into it
-  val byteArray1 = new ByteArray(Array())
-  val byteArray2 = new ByteArray(Array())
+  val byteArray1 = ByteArray(Array())
+  val byteArray2 = ByteArray(Array())
 
-  // Mock UnmovedRooks class (parameter for new Game)
+  // UnmovedRooks class (parameter for new Game)
   private val mockUnmovedRooks = UnmovedRooks(Set())
 
-  // Color values
-  private val white = White
-  private val black = Black
+  when(mockWhitePlayer.color).thenReturn(White)
+  when(mockBlackPlayer.color).thenReturn(Black)
 
-  when(mockWhitePlayer.color).thenReturn(white)
-  when(mockBlackPlayer.color).thenReturn(black)
-
-  // Other
   var gameId = "22222"
 
-  def getGameInstance(metadata: Metadata, whitePlayer: Player = mockWhitePlayer): Game =
-    Game(id = gameId, whitePlayer = mockWhitePlayer, blackPlayer = mockBlackPlayer, binaryPgn = byteArray1,
-      binaryPieces = byteArray2, turns = 0, startedAtTurn = 0, status = Status.Created, castleLastMoveTime = null,
+  def getGameInstance(metadata: Metadata = defaultMockMetadata, whitePlayer: Player = mockWhitePlayer,
+    blackPlayer: Player = mockBlackPlayer, status: Status = Status.Created): Game =
+    Game(id = gameId, whitePlayer = whitePlayer, blackPlayer = blackPlayer, binaryPgn = byteArray1,
+      binaryPieces = byteArray2, turns = 0, startedAtTurn = 0, status = status, castleLastMoveTime = null,
       unmovedRooks = mockUnmovedRooks, metadata = metadata, daysPerTurn = Some(1))
 
-  //-----------------
-  //     TESTS
-  //-----------------
-
-  // player(color: Color)
   "Players" should {
+
     "have a defining color" in {
-      val game = getGameInstance(defaultMockMetadata)
+      val game = getGameInstance()
 
-      game.player(white) must be(mockWhitePlayer)
-      game.player(black) must be(mockBlackPlayer)
-    }
-  }
-
-  // opponent(p: Player), opponent(c: Color)
-  "Opponent" should {
-    "have opposite color" in {
-      val mockPlayer = mock(classOf[Player])
-      val game = getGameInstance(defaultMockMetadata, mockPlayer)
-
-      when(mockPlayer.color).thenReturn(white)
-      game.opponent(mockPlayer) must be(mockBlackPlayer)
+      mockWhitePlayer.color must be(White)
+      mockBlackPlayer.color must be(Black)
+      game.player(White) must be(mockWhitePlayer)
+      game.player(Black) must be(mockBlackPlayer)
     }
   }
 
@@ -70,6 +52,8 @@ class GameTest extends Specification {
       val mockMetadata = mock(classOf[Metadata])
       val game = getGameInstance(mockMetadata)
 
+      when(mockMetadata.tournamentId).thenReturn(None)
+      game.isTournament must beFalse
       when(mockMetadata.tournamentId).thenReturn(Some("123"))
       game.isTournament must beTrue
       game.hasChat must beFalse
@@ -80,6 +64,9 @@ class GameTest extends Specification {
       val game = getGameInstance(mockMetadata)
 
       when(mockMetadata.tournamentId).thenReturn(None)
+      when(mockMetadata.simulId).thenReturn(None)
+      game.isSimul must beFalse
+      when(mockMetadata.tournamentId).thenReturn(None)
       when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isSimul must beTrue
       game.hasChat must beFalse
@@ -89,6 +76,9 @@ class GameTest extends Specification {
       val mockMetadata = mock(classOf[Metadata])
       val game = getGameInstance(mockMetadata)
 
+      when(mockMetadata.tournamentId).thenReturn(None)
+      when(mockMetadata.simulId).thenReturn(None)
+      game.isMandatory must beFalse
       when(mockMetadata.tournamentId).thenReturn(Some("123"))
       when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isMandatory must beTrue
@@ -109,18 +99,70 @@ class GameTest extends Specification {
       game.hasChat must beTrue
     }
 
-    "should have white as start color" in {
-      val game = getGameInstance(defaultMockMetadata)
+    "have white as start color" in {
+      val game = getGameInstance()
       mockWhitePlayer.color must be(chess.Color.White)
       game.startColor must be(chess.Color.White)
     }
 
-    "should be playable by default" in {
+    "be playable by default" in {
       val lobbyMetadata = mock(classOf[Metadata])
       when(lobbyMetadata.source).thenReturn(Some(Lobby))
 
       val game = getGameInstance(lobbyMetadata)
+      game.fromLobby must beTrue
       game.playable must beTrue
+    }
+
+    "not be playable if imported or aborted" in {
+      val importedMetadata = mock(classOf[Metadata])
+      when(importedMetadata.source).thenReturn(Some(Import))
+
+      val importedGame = getGameInstance(importedMetadata)
+
+      importedGame.imported must beTrue
+      importedGame.playable must beFalse
+      getGameInstance(status = Status.Aborted).playable must beFalse
+    }
+
+    "return correct player and opponent values" in {
+      val game = getGameInstance()
+      game.player must be(mockWhitePlayer)
+      game.opponent(game.player) must be(mockBlackPlayer)
+      game.opponent(mockWhitePlayer) must be(mockBlackPlayer)
+      game.opponent(mockBlackPlayer) must be(mockWhitePlayer)
+    }
+
+    "return the right amount of turns played" in {
+      val game = spy(getGameInstance())
+      when(game.startedAtTurn).thenReturn(0)
+      when(game.turns).thenReturn(10)
+      game.playedTurns must beEqualTo(10)
+
+      when(game.startedAtTurn).thenReturn(5)
+      game.playedTurns must beEqualTo(5)
+    }
+
+    "flag games that are out of time" in {
+      val game = spy(getGameInstance())
+      game.flagged must be(None)
+
+      when(game.status).thenReturn(Status.Outoftime)
+      game.flagged must beSome[Color](White)
+    }
+
+    "consider calculate proper average rating" in {
+      val weakPlayer = mock(classOf[Player])
+      val strongPlayer = mock(classOf[Player])
+
+      when(weakPlayer.rating).thenReturn(Some(1000))
+      when(strongPlayer.rating).thenReturn(Some(2000))
+
+      val game = spy(getGameInstance(whitePlayer = weakPlayer, blackPlayer = strongPlayer))
+      game.whitePlayer must be(weakPlayer)
+      game.blackPlayer must be(strongPlayer)
+      game.players must beEqualTo(List(weakPlayer, strongPlayer))
+      game.averageUsersRating must beSome[Int](1500)
     }
   }
 }

--- a/modules/game/src/test/GameTest.scala
+++ b/modules/game/src/test/GameTest.scala
@@ -1,7 +1,7 @@
 package lila.game
 
 import lila.db.ByteArray
-import chess.Color
+import chess.Color.{ White, Black }
 import chess.UnmovedRooks
 import org.mockito.Mockito._
 import org.specs2.mutable._
@@ -25,47 +25,26 @@ class GameTest extends Specification {
   private val mockUnmovedRooks = new UnmovedRooks(Set())
 
   // Color values
-  private val white = Color.White
-  private val black = Color.Black
+  private val white = White
+  private val black = Black
 
   // Other
   var gameId = "22222"
 
   // Game instance
-  var game = new Game(
-    gameId,
-    mockWhitePlayer,
-    mockBlackPlayer,
-    byteArray1,
-    byteArray2,
-    null,
-    0,
-    0,
-    null,
-    null,
-    mockUnmovedRooks,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    0,
-    null,
-    null,
-    mockMetadata
-  )
+  var game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+    mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
 
   //-----------------
   //     TESTS
   //-----------------
 
   // player(color: Color)
-  "Player" should {
+  "Players" should {
     "have a defining color" in {
+      val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
       game.player(white) must be(mockWhitePlayer)
       game.player(black) must be(mockBlackPlayer)
     }
@@ -74,39 +53,53 @@ class GameTest extends Specification {
   // opponent(p: Player), opponent(c: Color)
   "Opponent" should {
     "have opposite color" in {
+      val mockPlayer = mock(classOf[Player])
+      val game = new Game(gameId, mockPlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
       when(mockPlayer.color).thenReturn(white)
-      game.opponent(mockPlayer).color must be(Color.Black)
+      game.opponent(mockPlayer) must be(mockBlackPlayer)
     }
   }
 
-  // tournamentId, isTournament
   "Game" should {
+    // tournamentId, isTournament
     "be tournament" in {
+      val mockMetadata = mock(classOf[Metadata])
+      val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
       when(mockMetadata.tournamentId).thenReturn(Some("123"))
       game.isTournament must beTrue
     }
-  }
-
-  // simulId, isSimul
-  "Simul" should {
+    // simulId, isSimul
     "be simul" in {
+      val mockMetadata = mock(classOf[Metadata])
+      val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
       when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isSimul must beTrue
     }
-  }
-
-  // isMandatory, nonMandatory
-  "Simul" should {
+    // isMandatory, nonMandatory
     "be mandatory if either a tournament or simul is defined" in {
+      val mockMetadata = mock(classOf[Metadata])
+      val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
       when(mockMetadata.tournamentId).thenReturn(Some("123"))
+      when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isMandatory must beTrue
       game.nonMandatory must beFalse
     }
-  }
-
-  // hasChat, hasAi, nonAi
-  "hasChat" should {
+    // hasChat, hasAi, nonAi
     "have a chat if non tourney, non simul, and no AI" in {
+      val mockMetadata = mock(classOf[Metadata])
+      val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
+        mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
+
+      when(mockMetadata.tournamentId).thenReturn(None)
+      when(mockMetadata.simulId).thenReturn(None)
       when(mockWhitePlayer.isAi).thenReturn(false)
       when(mockBlackPlayer.isAi).thenReturn(false)
       game.hasAi must beFalse

--- a/modules/game/src/test/GameTest.scala
+++ b/modules/game/src/test/GameTest.scala
@@ -22,7 +22,7 @@ class GameTest extends Specification {
   val byteArray2 = new ByteArray(Array())
 
   // Mock UnmovedRooks class (parameter for new Game)
-  private val mockUnmovedRooks = new UnmovedRooks(Set())
+  private val mockUnmovedRooks = UnmovedRooks(Set())
 
   // Color values
   private val white = White
@@ -71,6 +71,7 @@ class GameTest extends Specification {
 
       when(mockMetadata.tournamentId).thenReturn(Some("123"))
       game.isTournament must beTrue
+      game.hasChat must beFalse
     }
     // simulId, isSimul
     "be simul" in {
@@ -78,8 +79,10 @@ class GameTest extends Specification {
       val game = new Game(gameId, mockWhitePlayer, mockBlackPlayer, byteArray1, byteArray2, null, 0, 0, null, null,
         mockUnmovedRooks, null, null, null, null, null, null, null, null, null, 0, null, null, mockMetadata)
 
+      when(mockMetadata.tournamentId).thenReturn(None)
       when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isSimul must beTrue
+      game.hasChat must beFalse
     }
     // isMandatory, nonMandatory
     "be mandatory if either a tournament or simul is defined" in {
@@ -91,6 +94,7 @@ class GameTest extends Specification {
       when(mockMetadata.simulId).thenReturn(Some("456"))
       game.isMandatory must beTrue
       game.nonMandatory must beFalse
+      game.hasChat must beFalse
     }
     // hasChat, hasAi, nonAi
     "have a chat if non tourney, non simul, and no AI" in {

--- a/modules/game/src/test/GameTest.scala
+++ b/modules/game/src/test/GameTest.scala
@@ -1,0 +1,105 @@
+package lila.game
+
+import lila.db.ByteArray
+import chess.Color
+import chess.UnmovedRooks
+import org.scalatest.FlatSpec
+import org.mockito.Mockito._
+
+class GameTest extends FlatSpec {
+
+  // Mock Player class
+  var mockPlayer = mock(classOf[Player])
+  var mockWhitePlayer = mock(classOf[Player])
+  var mockBlackPlayer = mock(classOf[Player])
+
+  // Mock Metadata class (parameter for new Game)
+  var mockMetadata = mock(classOf[Metadata])
+
+  // ByteArray instances (parameter for new Game)
+  // NOTE: Could not mock ByteArray, received error saying unable to mock static/final classes. Will look into it
+  var byteArray1 = new ByteArray(Array())
+  var byteArray2 = new ByteArray(Array())
+
+  // Mock UnmovedRooks class (parameter for new Game)
+  var mockUnmovedRooks = mock(classOf[UnmovedRooks])
+
+  // Color values
+  var white = Color.White
+  var black = Color.Black
+
+  // Other
+  var gameId = "22222"
+
+  // Game instance
+  var game = new Game(
+    gameId,
+    mockWhitePlayer,
+    mockBlackPlayer,
+    byteArray1,
+    byteArray2,
+    null,
+    0,
+    0,
+    null,
+    null,
+    mockUnmovedRooks,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    0,
+    null,
+    null,
+    mockMetadata
+  )
+
+  //-----------------
+  //     TESTS
+  //-----------------
+
+  // player(color: Color)
+  "Player" should "have a defining color" in {
+    assert(game.player(white) == mockWhitePlayer)
+    assert(game.player(black) == mockBlackPlayer)
+  }
+
+  // opponent(p: Player), opponent(c: Color)
+  "Opponent" should "have opposite color" in {
+    when(mockPlayer.color).thenReturn(white)
+    verify(game.opponent(mockPlayer).color == Color.Black)
+  }
+
+  // tournamentId, isTournament
+  "Game" should "be tournament" in {
+    when(mockMetadata.tournamentId).thenReturn(Some("123"))
+    assert(game.isTournament)
+  }
+
+  // simulId, isSimul
+  it should "be simul" in {
+    when(mockMetadata.simulId).thenReturn(Some("456"))
+    assert(game.isSimul)
+  }
+
+  // isMandatory, nonMandatory
+  it should "be mandatory if either a tournament or simul is defined" in {
+    when(mockMetadata.tournamentId).thenReturn(Some("123"))
+    assert(game.isMandatory == true)
+    assert(game.nonMandatory == false)
+  }
+
+  // hasChat, hasAi, nonAi
+  it should "have a chat if non tourney, non simul, and no AI" in {
+    when(mockWhitePlayer.isAi).thenReturn(false)
+    when(mockBlackPlayer.isAi).thenReturn(false)
+    assert(game.hasAi == false)
+    assert(game.nonAi == true)
+    assert(game.hasChat == true)
+  }
+}

--- a/modules/game/src/test/GameTest.scala
+++ b/modules/game/src/test/GameTest.scala
@@ -3,30 +3,30 @@ package lila.game
 import lila.db.ByteArray
 import chess.Color
 import chess.UnmovedRooks
-import org.scalatest.FlatSpec
 import org.mockito.Mockito._
+import org.specs2.mutable._
 
-class GameTest extends FlatSpec {
+class GameTest extends Specification {
 
   // Mock Player class
-  var mockPlayer = mock(classOf[Player])
-  var mockWhitePlayer = mock(classOf[Player])
-  var mockBlackPlayer = mock(classOf[Player])
+  private val mockPlayer = mock(classOf[Player])
+  private val mockWhitePlayer = mock(classOf[Player])
+  private val mockBlackPlayer = mock(classOf[Player])
 
   // Mock Metadata class (parameter for new Game)
-  var mockMetadata = mock(classOf[Metadata])
+  private val mockMetadata = mock(classOf[Metadata])
 
   // ByteArray instances (parameter for new Game)
   // NOTE: Could not mock ByteArray, received error saying unable to mock static/final classes. Will look into it
-  var byteArray1 = new ByteArray(Array())
-  var byteArray2 = new ByteArray(Array())
+  val byteArray1 = new ByteArray(Array())
+  val byteArray2 = new ByteArray(Array())
 
   // Mock UnmovedRooks class (parameter for new Game)
-  var mockUnmovedRooks = mock(classOf[UnmovedRooks])
+  private val mockUnmovedRooks = new UnmovedRooks(Set())
 
   // Color values
-  var white = Color.White
-  var black = Color.Black
+  private val white = Color.White
+  private val black = Color.Black
 
   // Other
   var gameId = "22222"
@@ -64,42 +64,54 @@ class GameTest extends FlatSpec {
   //-----------------
 
   // player(color: Color)
-  "Player" should "have a defining color" in {
-    assert(game.player(white) == mockWhitePlayer)
-    assert(game.player(black) == mockBlackPlayer)
+  "Player" should {
+    "have a defining color" in {
+      game.player(white) must be(mockWhitePlayer)
+      game.player(black) must be(mockBlackPlayer)
+    }
   }
 
   // opponent(p: Player), opponent(c: Color)
-  "Opponent" should "have opposite color" in {
-    when(mockPlayer.color).thenReturn(white)
-    verify(game.opponent(mockPlayer).color == Color.Black)
+  "Opponent" should {
+    "have opposite color" in {
+      when(mockPlayer.color).thenReturn(white)
+      game.opponent(mockPlayer).color must be(Color.Black)
+    }
   }
 
   // tournamentId, isTournament
-  "Game" should "be tournament" in {
-    when(mockMetadata.tournamentId).thenReturn(Some("123"))
-    assert(game.isTournament)
+  "Game" should {
+    "be tournament" in {
+      when(mockMetadata.tournamentId).thenReturn(Some("123"))
+      game.isTournament must beTrue
+    }
   }
 
   // simulId, isSimul
-  it should "be simul" in {
-    when(mockMetadata.simulId).thenReturn(Some("456"))
-    assert(game.isSimul)
+  "Simul" should {
+    "be simul" in {
+      when(mockMetadata.simulId).thenReturn(Some("456"))
+      game.isSimul must beTrue
+    }
   }
 
   // isMandatory, nonMandatory
-  it should "be mandatory if either a tournament or simul is defined" in {
-    when(mockMetadata.tournamentId).thenReturn(Some("123"))
-    assert(game.isMandatory == true)
-    assert(game.nonMandatory == false)
+  "Simul" should {
+    "be mandatory if either a tournament or simul is defined" in {
+      when(mockMetadata.tournamentId).thenReturn(Some("123"))
+      game.isMandatory must beTrue
+      game.nonMandatory must beFalse
+    }
   }
 
   // hasChat, hasAi, nonAi
-  it should "have a chat if non tourney, non simul, and no AI" in {
-    when(mockWhitePlayer.isAi).thenReturn(false)
-    when(mockBlackPlayer.isAi).thenReturn(false)
-    assert(game.hasAi == false)
-    assert(game.nonAi == true)
-    assert(game.hasChat == true)
+  "hasChat" should {
+    "have a chat if non tourney, non simul, and no AI" in {
+      when(mockWhitePlayer.isAi).thenReturn(false)
+      when(mockBlackPlayer.isAi).thenReturn(false)
+      game.hasAi must beFalse
+      game.nonAi must beTrue
+      game.hasChat must beTrue
+    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,7 @@ object Dependencies {
   val scaffeine = "com.github.blemale" %% "scaffeine" % "2.2.0" % "compile"
   val netty = "io.netty" % "netty" % "3.10.6.Final"
   val guava = "com.google.guava" % "guava" % "21.0"
+  val mockito = "org.mockito" % "mockito-core" % "1.10.19" % "test"
   val specs2 = "org.specs2" %% "specs2-core" % "3.9.2" % "test"
 
   object reactivemongo {


### PR DESCRIPTION
Added `GameTest.scala` to test the `Game.scala` functionality using mocks and spies.

* Added Mockito dependency
* Player 
  * Colour tests
* Game 
  * tournament tests
  * simul tests
  * mandatory tests
  * chat presences tests
  * start colour tests
  * playability tests
  * opponent player tests
  * turns played tests
  * flagging tests
  * average rating tests